### PR TITLE
Assemblies no longer use GUIDs for assembly references.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 </ul>
 <hr/>
 
+## [1.2.1 - 2021-08-07]
+
+### Changes:
+<ul>
+	<li> Assemblies no longer use GUIDs for assembly references. </il>
+</ul>
+<hr/>
+
 ## [1.2.0 - 2021-04-13]
 
 ### Additions:

--- a/Editor/com.actools.core.editor.asmdef
+++ b/Editor/com.actools.core.editor.asmdef
@@ -1,9 +1,8 @@
 {
     "name": "com.actools.core.editor",
     "references": [
-        "GUID:97d3a34ecf4c34e49992afd531182dea"
+        "com.actools.core.runtime"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -13,5 +12,6 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": []
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Runtime/com.actools.core.runtime.asmdef
+++ b/Runtime/com.actools.core.runtime.asmdef
@@ -1,3 +1,13 @@
-﻿{
-	"name": "com.actools.core.runtime"
+{
+    "name": "com.actools.core.runtime",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Tests/Editor/com.actools.core.tests.editor.asmdef
+++ b/Tests/Editor/com.actools.core.tests.editor.asmdef
@@ -1,10 +1,10 @@
 {
     "name": "com.actools.core.tests.editor",
     "references": [
-        "GUID:0acc523941302664db1f4e527237feb3",
-        "GUID:27619889b8ba8c24980f49ee34dbb44a",
-        "GUID:1c15b5fc7c88681498d59b0305d6855e",
-        "GUID:97d3a34ecf4c34e49992afd531182dea"
+        "UnityEditor.TestRunner",
+        "UnityEngine.TestRunner",
+        "com.actools.core.editor",
+        "com.actools.core.runtime"
     ],
     "includePlatforms": [
         "Editor"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.actools.core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "displayName": "ACTools: Core",
   "description": "This package contains core parts to ACTools packages. This includes things like extension methods, custom attributes, and dependencies for other ACTools that are made.",
   "unity": "2019.4",


### PR DESCRIPTION
## [1.2.1 - 2021-08-07]

### Changes:
<ul>
	<li> Assemblies no longer use GUIDs for assembly references. </il>
</ul>
<hr/>